### PR TITLE
when tonumber() is recorded as nil, specialize to the failing ctype

### DIFF
--- a/src/lj_crecord.c
+++ b/src/lj_crecord.c
@@ -1879,6 +1879,8 @@ void LJ_FASTCALL lj_crecord_tonumber(jit_State *J, RecordFFData *rd)
       d = ctype_get(cts, CTID_DOUBLE);
     J->base[0] = crec_ct_tv(J, d, 0, J->base[0], &rd->argv[0]);
   } else {
+    /* specialize to the ctype that couldn't be converted */
+    argv2cdata(J, J->base[0], &rd->argv[0]);
     J->base[0] = TREF_NIL;
   }
 }


### PR DESCRIPTION
bug report #408. a function was traced where a tonumber() couldn't convert a struct, so it returned constant nil (and optimized away). When called again with an int cdata, it just executed without checking the ctype.

this patch keeps the ctype guard even in the nil case.